### PR TITLE
Scram implant buff

### DIFF
--- a/Content.Server/Implants/Components/ScramImplantComponent.cs
+++ b/Content.Server/Implants/Components/ScramImplantComponent.cs
@@ -13,7 +13,7 @@ public sealed partial class ScramImplantComponent : Component
     /// Up to how far to teleport the user
     /// </summary>
     [DataField, ViewVariables(VVAccess.ReadWrite)]
-    public float TeleportRadius = 100f;
+    public float TeleportRadius = 500f;  // Goobstation - Scrambler buff
 
     [DataField, ViewVariables(VVAccess.ReadWrite)]
     public SoundSpecifier TeleportSound = new SoundPathSpecifier("/Audio/Effects/teleport_arrival.ogg");

--- a/Resources/Prototypes/Actions/types.yml
+++ b/Resources/Prototypes/Actions/types.yml
@@ -139,8 +139,7 @@
   components:
   - type: InstantAction
     checkCanInteract: false
-    charges: 2
-    useDelay: 5
+    useDelay: 30 # Goobstation - Scrambler buff
     itemIconStyle: BigAction
     priority: -20
     icon:

--- a/Resources/Prototypes/Catalog/uplink_catalog.yml
+++ b/Resources/Prototypes/Catalog/uplink_catalog.yml
@@ -1101,7 +1101,7 @@
   icon: { sprite: /Textures/Structures/Specific/anomaly.rsi, state: anom4 }
   productEntity: ScramImplanter
   cost:
-    Telecrystal: 6 # it's a gamble that may kill you easily so 6 TC per 2 uses, second one more of a backup
+    Telecrystal: 4 # Goobstation - Scrambler buff
   categories:
     - UplinkImplants
 


### PR DESCRIPTION
## About the PR
Buffed the scram implant, it now costs 4 TC, has unlimited uses but a 30 second cooldown and teleports you within 50 tiles.

please do not merge until i run the tests and make sure i am not missing anything

## Why / Balance
The scram implant is a bad utility implant since it barely teleports you 10 tiles and can only be used twice while taking up over 25% of your budget

## Technical details
scram implant range is the float / 10, hence 500 is 50

**Changelog**
🆑 
- Tweak: Scram implant has recieved a major buff.