### PR TITLE
Adds a new flavor book.

### DIFF
--- a/Resources/Locale/en-US/paper/book-authorbooks.ftl
+++ b/Resources/Locale/en-US/paper/book-authorbooks.ftl
@@ -261,3 +261,26 @@ book-text-janitor = [bold][color=black][head=3]The Tales of a Tired Janitor[/hea
       Speaking of jumpsuits, the lack of respect is astronomical. The scientists and astronauts zoom past in their sleek suits, utterly oblivious to the fact that I'm the unsung hero keeping this place from turning into a cosmic trash heap. I bet they don't even know my name. "Hey, Space Janitor!" That's what I get. No appreciation for the elbow grease I put into keeping their precious station spick and span.
       And let's remember the hazards. Cleaning up alien slime? Yeah, that's a regular Tuesday for me. One wrong move and I'm dealing with an intergalactic biohazard. It's like playing Russian roulette with space critters that could burst out of some hidden nook and cranny. I signed up to mop floors, not play host to extraterrestrial invaders.
       Being a janitor on this so-called Space Station 14 is a cosmic joke. Where did the other 13 stations go? It's not all spacewalks and futuristic gadgets; it's scrubbing toilets and battling alien goo. If anyone thinks space is glamorous, they clearly haven't seen the mess we space janitors deal with every single day. It's time they appreciate the unsung heroes of the space station – the custodians of the cosmos.
+
+book-text-maid =                   [head=2]The Lusty Unathi Janitor[/head]
+                        [bold]Authored by Netti Ingman
+
+[italic]Alfonso Huff, Captain of Space Station 41 runs into the unathi Janitor, Lifts-Her-Tail in the corridor.[/italic]
+
+      "I'm so glad I have found you, my dear. I spilled milk on the floor in the bridge. I need your services."
+      "I would love to help, Captain, but the Head of Persssonnel will take my head if I don't finisssh cleaning up thisss pool of blood."
+      "Oh, but I need a trusty Janitor to let into the bridge, and my heart trusts none but you, my dumpling."
+      "You flatter me, Captain. Alright, let'sss head to the bridge."
+
+      [italic]Lifts-Her-Tail grabs the janitorial trolley with her tail and they start walking. After a few minutes, they arrive to the bridge and she starts cleaning up. Her hands move skillfully and she wears an expression of professionalism, but she can not hide the slightest hint of blush that appears on her face whenever she notices the Captain taking glances at her. After a good 10 minutes of cleaning she turns to him.[/italic]
+
+      "I am done, Captain. Could you let me out through the High SSSecurity Doorsss?"
+      "Is cleaning the only reason you came here, little one?"
+      "I have to idea what it isss you imply. I am jussst a sssimple Janitor."
+      "So you are, my dumpling. And a good one at that. I saw your strong legs and tail as you pulled your trolley."
+      "You embarrasss me, SSSir."
+      "Fear not, you are safe from any Syndicate agent here with me."
+      "But I mussst continue my cleaning dutiesss."
+      "Cleaning, eh? I have something for you. Haven't I told you? I spilled the milk on my lap, and now my uniform is dirty."
+      "But thisss ssstain isss huge. It could take all night to ssscrub."
+      [bold]"Plenty of time, my sweet. Plenty of time."[bold]

--- a/Resources/Locale/en-US/paper/book-authorbooks.ftl
+++ b/Resources/Locale/en-US/paper/book-authorbooks.ftl
@@ -262,25 +262,4 @@ book-text-janitor = [bold][color=black][head=3]The Tales of a Tired Janitor[/hea
       And let's remember the hazards. Cleaning up alien slime? Yeah, that's a regular Tuesday for me. One wrong move and I'm dealing with an intergalactic biohazard. It's like playing Russian roulette with space critters that could burst out of some hidden nook and cranny. I signed up to mop floors, not play host to extraterrestrial invaders.
       Being a janitor on this so-called Space Station 14 is a cosmic joke. Where did the other 13 stations go? It's not all spacewalks and futuristic gadgets; it's scrubbing toilets and battling alien goo. If anyone thinks space is glamorous, they clearly haven't seen the mess we space janitors deal with every single day. It's time they appreciate the unsung heroes of the space station – the custodians of the cosmos.
 
-book-text-maid =                   [head=2]The Lusty Unathi Janitor[/head]
-                        [bold]Authored by Netti Ingman
-
-[italic]Alfonso Huff, Captain of Space Station 41 runs into the unathi Janitor, Lifts-Her-Tail in the corridor.[/italic]
-
-      "I'm so glad I have found you, my dear. I spilled milk on the floor in the bridge. I need your services."
-      "I would love to help, Captain, but the Head of Persssonnel will take my head if I don't finisssh cleaning up thisss pool of blood."
-      "Oh, but I need a trusty Janitor to let into the bridge, and my heart trusts none but you, my dumpling."
-      "You flatter me, Captain. Alright, let'sss head to the bridge."
-
-      [italic]Lifts-Her-Tail grabs the janitorial trolley with her tail and they start walking. After a few minutes, they arrive to the bridge and she starts cleaning up. Her hands move skillfully and she wears an expression of professionalism, but she can not hide the slightest hint of blush that appears on her face whenever she notices the Captain taking glances at her. After a good 10 minutes of cleaning she turns to him.[/italic]
-
-      "I am done, Captain. Could you let me out through the High SSSecurity Doorsss?"
-      "Is cleaning the only reason you came here, little one?"
-      "I have to idea what it isss you imply. I am jussst a sssimple Janitor."
-      "So you are, my dumpling. And a good one at that. I saw your strong legs and tail as you pulled your trolley."
-      "You embarrasss me, SSSir."
-      "Fear not, you are safe from any Syndicate agent here with me."
-      "But I mussst continue my cleaning dutiesss."
-      "Cleaning, eh? I have something for you. Haven't I told you? I spilled the milk on my lap, and now my uniform is dirty."
-      "But thisss ssstain isss huge. It could take all night to ssscrub."
-      [bold]"Plenty of time, my sweet. Plenty of time."[bold]
+book-text-maid = [italic]Alfonso Huff, Captain of Space Station 41 runs into the unathi Janitor, Lifts-Her-Tail in the corridor.[/italic] "I'm so glad I have found you, my dear. I spilled milk on the floor in the bridge. I need your services." "I would love to help, Captain, but the Head of Persssonnel will take my head if I don't finisssh cleaning up thisss pool of blood." "Oh, but I need a trusty Janitor to let into the bridge, and my heart trusts none but you, my dumpling." "You flatter me, Captain. Alright, let'sss head to the bridge." [italic]Lifts-Her-Tail grabs the janitorial trolley with her tail and they start walking. After a few minutes, they arrive to the bridge and she starts cleaning up. Her hands move skillfully and she wears an expression of professionalism, but she can not hide the slightest hint of blush that appears on her face whenever she notices the Captain taking glances at her. After a good 10 minutes of cleaning she turns to him.[/italic] "I am done, Captain. Could you let me out through the High SSSecurity Doorsss?" "Is cleaning the only reason you came here, little one?" "I have to idea what it isss you imply. I am jussst a sssimple Janitor." "So you are, my dumpling. And a good one at that. I saw your strong legs and tail as you pulled your trolley." "You embarrasss me, SSSir." "Fear not, you are safe from any Syndicate agent here with me." "But I mussst continue my cleaning dutiesss." "Cleaning, eh? I have something for you. Haven't I told you? I spilled the milk on my lap, and now my uniform is dirty." "But thisss ssstain isss huge. It could take all night to ssscrub." [bold]"Plenty of time, my sweet. Plenty of time."[bold]

--- a/Resources/Prototypes/Entities/Objects/Misc/books_author.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/books_author.yml
@@ -661,7 +661,7 @@
   parent: BookBase
   id: BookUnathiJanitor
   name: the lusty unathi janitor
-  description: A dirty book with even dirtier contents.
+  description: A dirty book with even dirtier contents. You feel like you should burn it.
   components:
   - type: Sprite
     sprite: Objects/Misc/books.rsi

--- a/Resources/Prototypes/Entities/Objects/Misc/books_author.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/books_author.yml
@@ -661,7 +661,7 @@
   parent: BookBase
   id: BookUnathiJanitor
   name: the lusty unathi janitor
-  description: A dirty book with even dirtier contents. You feel like you should burn it.
+  description: A dirty book with even dirtier contents. You feel like you should burn it, but you can't.
   components:
   - type: Sprite
     sprite: Objects/Misc/books.rsi

--- a/Resources/Prototypes/Entities/Objects/Misc/books_author.yml
+++ b/Resources/Prototypes/Entities/Objects/Misc/books_author.yml
@@ -657,3 +657,24 @@
   - type: Paper
     content: book-text-janitor
 
+- type: entity
+  parent: BookBase
+  id: BookUnathiJanitor
+  name: the lusty unathi janitor
+  description: A dirty book with even dirtier contents.
+  components:
+  - type: Sprite
+    sprite: Objects/Misc/books.rsi
+    layers:
+    - state: paper
+    - state: cover_old
+      color: "#c526de"
+    - state: decor_wingette
+    - state: icon_bucket
+    - state: detail_bookmark
+      color: "#61363d"
+    - state: icon_time
+      color: "#ffffff"
+  - type: Paper
+    content: book-text-maid
+


### PR DESCRIPTION
Writing credits go to Nettingman, small edit made by me, FBI, changing all mentions of "reptilian" to "unathi" to fit with EE lore.
 # Description

Adds the new flavor book, "The Lusty Unathi Janitor" that was pr'd to wizden and is still open iirc

---

# TODO

- [x] Add book prototype
- [x] Add locale

---

# Changelog

:cl:
- add: Added the Lusty Unathi Janitor
- remove: Removed sanity.
