### PR TITLE
Fixes the lollipop wear sprite

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -131,3 +131,13 @@
   components:
   - type: HumanoidAppearance
     species: Moth
+
+- type: entity
+  id: ActionToggleFlight
+  name: Fly
+  description: Make use of your wings to fly. Beat the flightless moth allegations.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: InstantAction
+    checkCanInteract: false
+    event: !type:ToggleFlightEvent

--- a/Resources/Prototypes/Nyanotrasen/Entities/Objects/Consumable/Food/candy.yml
+++ b/Resources/Prototypes/Nyanotrasen/Entities/Objects/Consumable/Food/candy.yml
@@ -24,7 +24,7 @@
     state: lollipop
   - type: Clothing
     slots: [mask]
-    sprite: Resources\Textures\Nyanotrasen\Objects\Consumable\Food\lollipop.rsi
+    sprite: Nyanotrasen/Objects/Consumable/Food/lollipop.rsi
 
 - type: entity
   parent: FoodBase


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

Fixes the lollipop so its clothing path no longer blew up the server, i was too verbose in where it was i guess. that's dumb.

---

# TODO

- [x] Fix path

---

# Changelog

:cl:
- fix: Fixed the lollipop so it didn't collapse the fabric of reality.
