### PR TITLE
Allows mothpeople to fly

### DIFF
--- a/Resources/Prototypes/Entities/Mobs/Species/moth.yml
+++ b/Resources/Prototypes/Entities/Mobs/Species/moth.yml
@@ -131,3 +131,13 @@
   components:
   - type: HumanoidAppearance
     species: Moth
+
+- type: entity
+  id: ActionToggleFlight
+  name: Fly
+  description: Make use of your wings to fly. Beat the flightless moth allegations.
+  categories: [ HideSpawnMenu ]
+  components:
+  - type: InstantAction
+    checkCanInteract: false
+    event: !type:ToggleFlightEvent


### PR DESCRIPTION
# Description

Gives mothpeople the ability to fly like a harpy, since they have fucking MASSIVE wings. They still cannot hold anything, solely because if they could it would be BROKEN as fuck. I also don't want to. This also gives me an excuse to not reduce stamina drain. Lore reason is just that it's exhausting.

---

# TODO

- [x] Add the flight action to moth.yml (species)

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

---

# Changelog

:cl:
- add: Gave mothpeople the ability to fly! Flap to your heart's content!