### PR TITLE
Restore HoP access

### DIFF
--- a/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
+++ b/Resources/Prototypes/Roles/Jobs/Command/head_of_personnel.yml
@@ -34,7 +34,7 @@
   - Janitor
   - Theatre
   - Kitchen
-#  - Chapel
+  - Chapel
   - Hydroponics
   - External
   - Cryogenics
@@ -42,17 +42,18 @@
   # As of 15/03/23 they can't do that so here's MOST of the rest of the access levels.
   # Head level access that isn't their own was deliberately left out, get AA from the captain instead.
   # Delta V - fuck all of this HoP is a service role
-#  - Chemistry
-#  - Engineering
-#  - Research
-#  - Detective
-#  - Salvage
-#  - Security # NoooOoOo!! My HoPcurity!1
-#  - Brig
+  # Arcadis - fuck all of this HoP is second to captain
+  - Chemistry
+  - Engineering
+  - Research
+  - Detective
+  - Salvage
+  - Security # NoooOoOo!! My HoPcurity!1 #too bad it going to reexisted
+  - Brig
   - Lawyer
   - Cargo
-#  - Atmospherics
-#  - Medical
+  - Atmospherics
+  - Medical
   - Boxer # DeltaV - Add Boxer access
   - Clown # DeltaV - Add Clown access
   - Library # DeltaV - Add Library access


### PR DESCRIPTION
# Description

essentially uncomment those comment in hop roles

---
# Changelog

:cl:
- tweak: The Head of Personnel has had their pseudo-AA returned to them.