### PR TITLE
fix viperfang desc

### DIFF
--- a/Resources/Prototypes/_Arc/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
+++ b/Resources/Prototypes/_Arc/Entities/Objects/Weapons/Guns/Rifles/rifles.yml
@@ -3,7 +3,7 @@
   name: Viperfang
   parent: BaseWeaponRifle
   id: WeaponRifleFang
-  description: An reliable assault rifle. That uses .30 rifle ammo.
+  description: An reliable assault rifle. That uses .20 rifle ammo.
   components:
   - type: Sprite
     sprite: /Textures/_Arc/Objects/Weapons/Guns/Rifles/viperfang.rsi


### PR DESCRIPTION
---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: fixed viperfang description to mention correct ammo type