### PR TITLE
Update lathe.yml

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
+++ b/Resources/Prototypes/Entities/Structures/Machines/lathe.yml
@@ -1046,6 +1046,10 @@
       - WeaponMechCombatDisabler
       - WeaponMechCombatFlashbangLauncher
       - WeaponMechCombatMissileRack8
+      - PowercellRiflemagcr # Arcadis - rifle power cell magazine
+      - PowercellRailgunmagcr # Arcadis - railgun power cell magazine
+      - WeaponLaserAssaultLaserRifleCR # Arcadis - CRT-20 Laser Assault Rifle
+      - WeaponRailgunUziRefrenceCR # Arcadis - CRT-21 Laser Railgun
   - type: MaterialStorage
     whitelist:
       tags:


### PR DESCRIPTION
put back the railgun and assault rifle into secfab

<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

the shit somehow lost during ee mech update.
<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

Description.

---

# TODO

<!--
A list of everything you have to do before this PR is "complete"
You probably won't have to complete everything before merging but it's good to leave future references
-->

- [ ] Task
- [x] Completed Task

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<details><summary><h1>Media</h1></summary>
<p>

![Example Media Embed](https://example.com/thisimageisntreal.png)

</p>
</details>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- fix: railgun and laser assault rifle is printable on secfab once more.
