### PR TITLE
minor tweaks to merc and NTPD spawns

### DIFF
--- a/Resources/Prototypes/_Arc/Ghostroles/humanoid.yml
+++ b/Resources/Prototypes/_Arc/Ghostroles/humanoid.yml
@@ -20,6 +20,7 @@
   randomizeName: false
   speciesBlacklist:
     - Shadowkin
+    - Plasmaman
   components:
     - type: MindShield
     - type: Loadout
@@ -72,6 +73,7 @@
   randomizeName: false
   speciesBlacklist:
     - Shadowkin
+    - Plasmaman
   components:
     - type: MindShield
     - type: Loadout
@@ -108,8 +110,8 @@
       state: full
     - type: RandomMetadata
       nameSegments:
-        - NamesFirstmerc
-        - NamesLastmerc
+        - names_first
+        - names_last
     - type: RandomHumanoidSpawner
       settings: MERCSettings
 
@@ -118,14 +120,15 @@
   randomizeName: false
   speciesBlacklist:
     - Shadowkin
+    - Plasmaman
   components:
     - type: MindShield
     - type: Loadout
       prototypes: [ MERCGear ]
     - type: RandomMetadata
       nameSegments:
-        - NamesFirstmerc
-        - NamesLastmerc
+        - names_first
+        - names_last
 
 # Merc Gear
 
@@ -137,6 +140,7 @@
     mask: ClothingMaskGasMerc
     ears: ClothingHeadsetMERC
     gloves: ClothingHandsGlovesCombat
+    outerClothing: ClothingOuterVestWebMerc
     suitstorage: AirTankFilled
     shoes: ClothingShoesBootsMerc
     id: MERCPDA


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

<!--
Explain this PR in as much detail as applicable

Some example prompts to consider:
How might this affect the game? The codebase?
What might be some alternatives to this?
How/Who does this benefit/hurt [the game/codebase]?
-->

blacklists plasmamen (these roles do not have envirosuits and the plasmamen just die instantly) and changes merc names to normal names instead of whatever the hell is going on [in here](https://github.com/The-Arcadis-Team/arc-station-14/blob/434a9518d8612eacf440700dfcec06bfda7c80c9/Resources/Prototypes/Datasets/Names/Merc.yml)

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: Mercenary and NTPD roles will no longer spawn Plasmamen, leading to a record 100% decrease in horrible deaths.
- tweak: Mercenary preset names are now normal.
