### PR TITLE
set Harmony's Central Command as the only Central Command

### DIFF
--- a/Content.Server/Shuttles/Components/StationCentcommComponent.cs
+++ b/Content.Server/Shuttles/Components/StationCentcommComponent.cs
@@ -18,7 +18,7 @@ public sealed partial class StationCentcommComponent : Component
     [DataField]
     public List<ResPath> Maps = new()
     {
-        new("/Maps/CentralCommand/main.yml"),
+       // new("/Maps/CentralCommand/main.yml"),
         new("/Maps/CentralCommand/harmony.yml")
     };
 


### PR DESCRIPTION
<!--
This is a semi-strict format, you can add/remove sections as needed but the order/format should be kept the same
Remove these comments before submitting
-->

# Description

title
it's just an objectively better laid out and equipped CC in every way

this PR just comments out the old one from the list of spawns, so it can be reenabled if desired

---

<!--
This is default collapsed, readers click to expand it and see all your media
The PR media section can get very large at times, so this is a good way to keep it clean
The title is written using HTML tags
The title must be within the <summary> tags or you won't see it
-->

<summary><h1>Media</h1></summary>
<p>

![image](https://github.com/user-attachments/assets/ad88e37d-6f5e-45fd-b792-04717e1084f9)

</p>

---

# Changelog

<!--
You can add an author after the `:cl:` to change the name that appears in the changelog (ex: `:cl: Death`)
Leaving it blank will default to your GitHub display name
This includes all available types for the changelog
-->

:cl:
- tweak: The newer Central Command version is now guaranteed to spawn. 
