### PR TITLE
EMERGENCY FIX

### DIFF
--- a/Resources/Prototypes/_Arc/Trio.yml
+++ b/Resources/Prototypes/_Arc/Trio.yml
@@ -228,7 +228,6 @@
     - Crab
     - Sign
   - type: FootPrints
-  - type: Flashable
   - type: PassiveDamage
     allowedStates:
     - Alive


### PR DESCRIPTION
EMERGENCY FIX, REMOVES THE FLASHABLE COMPONENT FROM BASETRIOMOB SINCE IT'S BREAKING EVERYTHING